### PR TITLE
refactor: rename scrolled class to scroll for nav states

### DIFF
--- a/src/components/global/Navigation.astro
+++ b/src/components/global/Navigation.astro
@@ -22,24 +22,23 @@ const baseClass = [
   "justify-center",
   "top-0",
 
-  "backdrop-blur-none",
+  "backdrop-blur-md",
   "bg-transparent",
-  "scrolled:backdrop-blur-md",
-  "scrolled:bg-base-100/70",
-  "scrolled:dark:bg-base-800/70",
+  "bg-base-100/70",
+  "dark:bg-base-800/70",
 
-  "transition-[padding,background-color,backdrop-filter,box-shadow,border-color]",
-  "scrolled:duration-300",
-  "scrolled:ease-in-out",
+  // "transition-[background-color, padding,backdrop-filter,box-shadow,border-color]",
+  // "duration-300",
+  // "ease-in-out",
 
   "py-8",
   "lg:py-11",
-  "scrolled:py-3",
+  "scroll:py-3",
 
-  "scrolled:shadow-md",
-  "scrolled:border-b",
-  "scrolled:border-base-600/10",
-  "scrolled:dark:border-base-600/10",
+  "scroll:shadow-md",
+  "scroll:border-b",
+  "scroll:border-base-600/10",
+  "scroll:dark:border-base-600/10",
 ];
 
 const navItems = [
@@ -119,7 +118,7 @@ const navItems = [
       </div>
     </div>
 
-    <div class="progress-bar scrolled:block absolute right-0 -bottom-0.5 -left-0 hidden h-1 px-4 sm:px-12 md:px-1">
+    <div class="progress-bar scroll:block absolute right-0 -bottom-0.5 -left-0 hidden h-1 px-4 sm:px-12 md:px-1">
       <div
         id="readingProgress"
         class="from-primary-300 to-primary-600 h-full w-0 rounded-full bg-gradient-to-r transition-[width] duration-50"

--- a/src/components/head/BaseHead.astro
+++ b/src/components/head/BaseHead.astro
@@ -13,7 +13,8 @@ import ToggleMobileSidenav from "@/lib/scripts/MainNav/ToggleMobileSidenav.astro
 import ToTopMobileNav from "@/lib/scripts/MainNav/ToTopMobileNav.astro";
 
 import ReadingProgressBar from "@/lib/scripts/MainNav/ReadingProgressBar.astro";
-import ShrinkMainnav from "@/lib/scripts/MainNav/ShrinkMainnav.astro";
+import UpdateScroll from "@/lib/scripts/UpdateScroll.astro";
+import AddTransitionClasses from "@/lib/scripts/MainNav/AddTransitionClasses.astro";
 
 export interface Props {
   pageTitle?: string;
@@ -31,7 +32,7 @@ const { pageTitle, pageDescription, image, article, publishDate, modifiedDate, a
 <!-- Critical scripts -->
 <UpdateTheme />
 <UpdateZoom />
-<ShrinkMainnav />
+<UpdateScroll />
 <ToggleNavActive />
 
 <Fonts />
@@ -54,3 +55,4 @@ const { pageTitle, pageDescription, image, article, publishDate, modifiedDate, a
 <ToTopMobileNav />
 <ToggleMobileSidenav />
 <ToggleA11ytip />
+<AddTransitionClasses />

--- a/src/lib/scripts/MainNav/AddTransitionClasses.astro
+++ b/src/lib/scripts/MainNav/AddTransitionClasses.astro
@@ -1,0 +1,13 @@
+<script>
+  // Dirty fix so that the nav doesn't animate on page is scrolled and reload.
+  const transitionClasses = [
+    "transition-[background-color,padding,backdrop-filter,box-shadow,border-color]",
+    "duration-300",
+    "ease-in-out",
+  ];
+
+  const mainNav = document.querySelector("#mainNav");
+  if (mainNav) {
+    transitionClasses.forEach((c) => mainNav.classList.add(c));
+  }
+</script>

--- a/src/lib/scripts/UpdateScroll.astro
+++ b/src/lib/scripts/UpdateScroll.astro
@@ -3,7 +3,7 @@
     const SCROLL_THRESHOLD = 48;
 
     function updateScrollState() {
-      document.documentElement.classList.toggle("scrolled", window.scrollY > SCROLL_THRESHOLD);
+      document.documentElement.classList.toggle("scroll", window.scrollY > SCROLL_THRESHOLD);
     }
 
     updateScrollState();

--- a/src/lib/shared/abstracts.ts
+++ b/src/lib/shared/abstracts.ts
@@ -1,4 +1,5 @@
 export const stackGrid = [
+  "mt-0.5",
   "grid",
   "grid-cols-1",
   "lg:grid-cols-3",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -252,4 +252,4 @@ code .line::before {
     --text-9xl--line-height: calc(1 * var(--zoom-factor, 1));
 }
 
-@custom-variant scrolled (&:where(.scrolled, .scrolled *));
+@custom-variant scroll (&:where(.scroll, .scroll *));


### PR DESCRIPTION
* Rename CSS custom variant from `scrolled` to `scroll` in global.css
* Replace `scrolled` class with `scroll` in Navigation.astro markup
* Move nav transition classes to separate AddTransitionClasses.astro script
* Rename ShrinkMainnav.astro to UpdateScroll.astro
* Add `mt-0.5` to stackGrid base classes