### PR TITLE
config: remove trailing slashes from page URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,8 @@ import mailObfuscation from "astro-mail-obfuscation";
 
 // https://astro.build/config
 export default defineConfig({
+  trailingSlash: "never",
+
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
* Set `trailingSlash` option to "never" in Astro configuration