### PR TITLE
refactor: rename variable from zoom to theme

### DIFF
--- a/src/lib/scripts/UpdateTheme.astro
+++ b/src/lib/scripts/UpdateTheme.astro
@@ -1,6 +1,6 @@
 <script is:inline>
-  const zoomStored = localStorage.getItem("themeDark") === "true";
-  document.documentElement.classList.toggle("dark", zoomStored);
+  const themeStored = localStorage.getItem("themeDark") === "true";
+  document.documentElement.classList.toggle("dark", themeStored);
 
   function updateZoom(enableZoom) {
     document.documentElement.classList.toggle("dark", enableZoom);


### PR DESCRIPTION
* Renamed `zoomStored` to `themeStored` in `UpdateTheme.astro`
* Corrected variable name usage in `classList.toggle()` call