### PR TITLE
refactor: Remove redundant word in heading text

### DIFF
--- a/src/pages/_landing/Intro.astro
+++ b/src/pages/_landing/Intro.astro
@@ -40,12 +40,12 @@ const imgClasses = ["aspect-12/8", "lg:aspect-square", "sm:w-2/3", "lg:w-full", 
         <!-- Desktop -->
         <Wrapper variant="proseBase">
           <Text tag="h1" variant="textXL" class="hidden sm:block" isPrimary>
-            <span id="designYear">9</span>+ Jahre Design Expertise trifft auf
+            <span id="designYear">9</span>+ Jahre Design Expertise trifft
             <br class="hidden sm:block" />
             <span id="devYear">7</span>+ Jahre moderne Web-Entwicklung
           </Text>
           <Text tag="h1" variant="textLG" class="!font-bold sm:hidden" isPrimary>
-            <span id="designYear">9</span>+ Jahre Design Expertise trifft auf
+            <span id="designYear">9</span>+ Jahre Design Expertise trifft
             <br />
             <span id="devYear">7</span>+ Jahre moderne Web-Entwicklung
           </Text>


### PR DESCRIPTION
* Removed word "auf" from heading text in desktop and mobile versions